### PR TITLE
feat: add `setsockopt` for `SO_REUSEPORT`

### DIFF
--- a/src/socket/CServerSocket.cpp
+++ b/src/socket/CServerSocket.cpp
@@ -30,6 +30,11 @@ CServerSocket::CServerSocket(int port, int num_of_connections, TypeSocket type) 
         std::cout << "Failed to create Socket Descriptor " << std::endl;
         throw std::runtime_error("INVALID_SOCKET");
     }
+    int enable = 1;
+    if (setsockopt(s_, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable)) < 0) {
+        std::cout << "setsockopt(SO_REUSEADDR) failed" << std::endl;
+        throw std::runtime_error("setsockopt(SO_REUSEADDR) failed");
+    }
 
     if (type == NonBlockingSocket)
     {


### PR DESCRIPTION
# Description

- add socket option for the bind issue that happens when we close the server and start it again
- When a process terminates, its corresponding socket closes. When this happens, the socket enters a state called TIME_WAIT. This is where any rogue packets that haven’t yet found their way to their destination are given time to reach their destination eventually. During this time, the address/port combination bound to the socket isn’t available for use.
- Another socket won’t be able to use the IP address and port combination of the socket in the TIME_WAIT state unless both sockets have the SO_REUSEPORT option.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules

