### PR TITLE
build: export compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.backup
 lib
 lib/*
+.cache/clangd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(AsabruEngine)
+# Enables generation of compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Set DEBUG preprocessor flag
 add_compile_definitions(DEBUG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(asabru_engine)
+# Enables generation of compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(../include)
 include_directories(../../libuv/include)


### PR DESCRIPTION
# Description

This just improves the developer experience for those using **clangd**.

- changes to generate compile_commands.json
- ignore **clangd** cache

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

