### PR TITLE
fix: ssl ctx leak

### DIFF
--- a/src/socket/SSLSocket.cpp
+++ b/src/socket/SSLSocket.cpp
@@ -276,4 +276,5 @@ void SSLSocket::SendBytes(char *s, int length) {
 void SSLSocket::Close() {
 	SSL_shutdown(ssl);
 	SSL_free(ssl);
+	SSL_CTX_free(ctx);
 }


### PR DESCRIPTION
# Description

SSL ctx was not getting freed when SSLSocket was closed. This caused a leak.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
